### PR TITLE
Added some additional fallback icon sets

### DIFF
--- a/Obsidian/index.theme
+++ b/Obsidian/index.theme
@@ -1,6 +1,6 @@
 [Icon Theme]
 Name=Obsidian
-Inherits=Ambiant-MATE,Mint-X,Faenza-Dark,KFaenza,gnome,hicolor
+Inherits=Ambiant-MATE,Mint-X,Faenza-Dark,KFaenza,gnome,hicolor,Adwaita,elementary,Breeze
 Comment=Icon theme project with tilish style, by Tiheum modified by madmaxms
 Directories=actions/16,actions/16s,apps/16,apps/16s,appscol/16,categories/16,devices/16,emblems/16,mimetypes/16,places/16,places/16s,status/16,stock/16,actions/22,actions/22s,apps/22,appscol/22,categories/22,devices/22,emblems/22,mimetypes/22,places/22,status/22,status/22s,stock/22,actions/24,actions/24s,apps/24,appscol/24,categories/24,devices/24,emblems/24,mimetypes/24,places/24,status/24,stock/24,actions/32,apps/32,appscol/32,categories/32,devices/32,emblems/32,mimetypes/32,places/32,status/32,stock/32,actions/48,apps/48,appscol/48,categories/48,devices/48,emblems/48,mimetypes/48,places/48,status/48,stock/48,actions/64,categories/64,devices/64,emblems/64,mimetypes/64,places/64,status/64,stock/64,actions/96,apps/96,appscol/96,categories/96,devices/96,emblems/96,mimetypes/96,places/96,status/96,stock/96,actions/scalable,apps/scalable,categories/scalable,devices/scalable,emblems/scalable,status/16s,stock/scalable
 


### PR DESCRIPTION
By doing this, any icons GNOME, elementary OS, and KDE Plasma add should be accounted for automatically by the icon set, during times that the icon set is lacking those icons, instead of resulting in applications being littered with 'missing icon' icons in worst case scenarios.